### PR TITLE
Allow iodata for log message input and tolerate poorly formed messages.

### DIFF
--- a/lib/ex_winlog.ex
+++ b/lib/ex_winlog.ex
@@ -54,7 +54,16 @@ defmodule ExWinlog do
         %{level: min_level, event_source_name: event_source_name} = state
       ) do
     if is_nil(min_level) or Logger.compare_levels(level, min_level) != :lt do
-      :ok = apply(ExWinlog.Logger, level, [event_source_name, msg])
+      try do
+          case msg do
+              msg_iodata when is_list(msg_iodata) -> 
+                  :ok = apply(ExWinlog.Logger, level, [event_source_name, IO.iodata_to_binary(msg_iodata)])
+              msg_binary when is_binary(msg_binary) ->
+                  :ok = apply(ExWinlog.Logger, level, [event_source_name, msg_binary]) 
+          end
+      catch _,_ -> 
+           :ok
+      end
     end
 
     {:ok, state}


### PR DESCRIPTION
REASON: Phoenix sends iodata that looks like: ["GET",32, "/path/to/whatever"] into handle_event's msg. The 32 is just a character code for a space. I get the following error at every access to a phoenix route:

** (stop) {:EXIT, {:badarg, [{ExWinlog.Nif, :info, ["AppName", ["POST", 32, "/api/getpendingcount"]], []}, {ExWinlog, :handle_event, 2, [file: 'lib/ex_winlog.ex', line: 57]}, {:gen_event, :server_update, 4, [file: 'gen_event.erl', line: 620]}, {:gen_event, :server_notify, 4, [file: 'gen_event.erl', line: 602]}, {:gen_event, :handle_msg, 6, [file: 'gen_event.erl', line: 343]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 226]}]}}
Last message: {:gen_event_EXIT, {ExWinlog, "AppName"}, {:EXIT, {:badarg, [{ExWinlog.Nif, :info, ["AppName", ["POST", 32, "/api/getpendingcount"]], []}, {ExWinlog, :handle_event, 2, [file: 'lib/ex_winlog.ex', line: 57]}, {:gen_event, :server_update, 4, [file: 'gen_event.erl', line: 620]}, {:gen_event, :server_notify, 4, [file: 'gen_event.erl', line: 602]}, {:gen_event, :handle_msg, 6, [file: 'gen_event.erl', line: 343]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 226]}]}}}


If bad messages come in at a high enough rate, it can cause the supervisor to give up,
which brings down the whole app. Given the conditional nature of logging it is difficult
to test all log statements in an application, so I'd personally rather the app stay
running than crash the app for the logging case. We may want to do something in the catch/2
to indicate that something went wrong with the msg format, but this commit doesn't
address that. Perhaps logging a subset of the metadata indicating where the problem may be,
because we certainly can't log the msg if it's bad. A simple "inspect" may also cause problems, 
so I just elected to be more tolerant in that case in an admittedly non-transparent way.